### PR TITLE
Make linux window harder to find when not required

### DIFF
--- a/linux/player.hpp
+++ b/linux/player.hpp
@@ -204,7 +204,6 @@ Player::Player(int32_t id, bool show_window = false,
                std::string window_title = "libwinmedia")
     : id_(id) {
   auto m_window = gtk_window_new(show_window ? GTK_WINDOW_TOPLEVEL : GTK_WINDOW_POPUP);
-  gtk_window_set_title(GTK_WINDOW(m_window), window_title.c_str());
   if (show_window) {
     gtk_window_resize(GTK_WINDOW(m_window), 480, 360);
   } else {
@@ -212,6 +211,7 @@ Player::Player(int32_t id, bool show_window = false,
   }
 
   webview_ = std::make_unique<webview::webview>(true, m_window);
+  webview_->set_title(window_title);
   if (!show_window) {
     gtk_widget_hide(GTK_WIDGET(webview_->window()));
   }


### PR DESCRIPTION
Current version shows a temporary window even if show_window is `false`. Constructor of `webview::webview` always calls `gtk_widget_show_all`, which displays the window.

https://github.com/webview/webview/blob/f540d88dde4ebb2108833cf0a413742941ce4eca/webview.h#L502

This PR makes the window harder to find by doing:
1. Set window type to `GTK_WINDOW_POPUP`. This type of window has no border and does not display in taskbar.
2. Resize window to `width=1, height=1`.
3. Then hide the window(widget)