### PR TITLE
18: fix locale issues with printing using std::to_string for floats

### DIFF
--- a/linux/player.hpp
+++ b/linux/player.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <charconv>
 
 #include "../external/webview/webview.h"
 
@@ -407,12 +408,27 @@ void Player::Seek(int32_t position) {
 
 void Player::SetVolume(float volume) {
   EnsureFuture();
-  webview_->eval("player.volume = " + std::to_string(volume) + ";");
+
+  std::array<char, 32> buf;
+  auto result = std::to_chars(buf.data(), buf.data() + buf.size(), volume);
+  if (result.ec == std::errc()) {
+    auto str = std::string(buf.data(), result.ptr - buf.data());
+    webview_->eval("player.volume = " + str + ";");
+  } else {
+    // handle the error
+  }
 }
 
 void Player::SetRate(float rate) {
   EnsureFuture();
-  webview_->eval("player.playbackRate = " + std::to_string(rate) + ";");
+  std::array<char, 32> buf;
+  auto result = std::to_chars(buf.data(), buf.data() + buf.size(), rate);
+  if (result.ec == std::errc()) {
+    auto str = std::string(buf.data(), result.ptr - buf.data());
+    webview_->eval("player.playbackRate = " + str + ";");
+  } else {
+    // handle the error
+  }
 }
 
 void Player::SetIsAutoRepeat(bool is_autorepeat) {


### PR DESCRIPTION
Fixes #18 

std::to_string output depends on the locale on the machine it happens to be running on. For floats, this produces invalid output with comma instead of period as a decimal separator, such as `0,3` instead of `0.3`.

